### PR TITLE
feat: add facebook marketing insights service

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,10 @@
+const { fetchFacebookInsights } = require('./services/facebook');
+
+(async () => {
+  try {
+    const data = await fetchFacebookInsights();
+    console.log(JSON.stringify(data, null, 2));
+  } catch (err) {
+    console.error('Error fetching insights:', err.message);
+  }
+})();


### PR DESCRIPTION
## Summary
- add service to fetch Facebook campaign insights with pagination and retries
- include example index script demonstrating usage

## Testing
- `node --check services/facebook.js`
- `node --check index.js`
- `npm test` *(fails: enoent Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689522b1d708832bb7db313d34b05993