### PR TITLE
Improve summary and rows API stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,10 +117,29 @@ curl http://localhost:3005/api/last-sync
 - Large exports may take time to stream.
 
 ### Suggested indexes
-Add these indexes to PostgreSQL for best performance:
-- `(date_start, platform)`
-- `(campaign_name)`
-- `(account_id)`
+Ensure these indexes exist for best performance. The `ensureIndexes.js` helper can create them or run the DDL manually:
+
+```sql
+CREATE INDEX IF NOT EXISTS facebook_ad_insights_date_start_platform_idx ON facebook_ad_insights(date_start, platform);
+CREATE INDEX IF NOT EXISTS facebook_ad_insights_campaign_name_idx ON facebook_ad_insights(campaign_name);
+CREATE INDEX IF NOT EXISTS facebook_ad_insights_account_id_idx ON facebook_ad_insights(account_id);
+CREATE INDEX IF NOT EXISTS youtube_ad_insights_date_start_platform_idx ON youtube_ad_insights(date_start, platform);
+CREATE INDEX IF NOT EXISTS youtube_ad_insights_campaign_name_idx ON youtube_ad_insights(campaign_name);
+CREATE INDEX IF NOT EXISTS youtube_ad_insights_account_id_idx ON youtube_ad_insights(account_id);
+```
+
+Run once:
+
+```bash
+node ensureIndexes.js
+```
+
+### Query plan logging
+To inspect query plans locally, run:
+
+```bash
+node planLogger.js
+```
 
 ## Backfill
 Run historical pulls between two dates:

--- a/db.js
+++ b/db.js
@@ -1,0 +1,30 @@
+import { pool } from './syncLog.js';
+
+let failCount = 0;
+let breakerUntil = 0;
+
+export async function queryWithRetry(sql, params = [], attempt = 1) {
+  if (Date.now() < breakerUntil) {
+    const err = new Error('Database temporarily unavailable');
+    err.code = 'EBREAKER';
+    throw err;
+  }
+  try {
+    const res = await pool.query(sql, params);
+    failCount = 0;
+    return res;
+  } catch (err) {
+    if (['ECONNRESET', 'ETIMEDOUT'].includes(err.code) && attempt < 5) {
+      failCount++;
+      if (failCount >= 5) {
+        breakerUntil = Date.now() + 30000; // open circuit for 30s
+      }
+      const delay = 100 * Math.pow(2, attempt - 1);
+      await new Promise((r) => setTimeout(r, delay));
+      return queryWithRetry(sql, params, attempt + 1);
+    }
+    const wrapped = new Error(`Database query failed: ${err.message}`);
+    wrapped.code = err.code;
+    throw wrapped;
+  }
+}

--- a/ensureIndexes.js
+++ b/ensureIndexes.js
@@ -1,0 +1,33 @@
+import { pool } from './syncLog.js';
+
+const statements = [
+  `CREATE INDEX IF NOT EXISTS facebook_ad_insights_date_start_platform_idx ON facebook_ad_insights(date_start, platform)`,
+  `CREATE INDEX IF NOT EXISTS facebook_ad_insights_campaign_name_idx ON facebook_ad_insights(campaign_name)`,
+  `CREATE INDEX IF NOT EXISTS facebook_ad_insights_account_id_idx ON facebook_ad_insights(account_id)`,
+  `CREATE INDEX IF NOT EXISTS youtube_ad_insights_date_start_platform_idx ON youtube_ad_insights(date_start, platform)`,
+  `CREATE INDEX IF NOT EXISTS youtube_ad_insights_campaign_name_idx ON youtube_ad_insights(campaign_name)`,
+  `CREATE INDEX IF NOT EXISTS youtube_ad_insights_account_id_idx ON youtube_ad_insights(account_id)`
+];
+
+export async function ensureIndexes() {
+  const client = await pool.connect();
+  try {
+    for (const sql of statements) {
+      await client.query(sql);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  ensureIndexes()
+    .then(() => {
+      console.log('Indexes ensured');
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error('Failed to ensure indexes', err);
+      process.exit(1);
+    });
+}

--- a/planLogger.js
+++ b/planLogger.js
@@ -1,0 +1,53 @@
+import { pool } from './syncLog.js';
+import { log } from './logger.js';
+
+export async function logPlans() {
+  const client = await pool.connect();
+  try {
+    const queries = [
+      {
+        name: 'facebook-summary',
+        sql: `EXPLAIN ANALYZE SELECT COALESCE(SUM(spend),0) FROM facebook_ad_insights WHERE date_start >= CURRENT_DATE - INTERVAL '7 days'`,
+      },
+      {
+        name: 'youtube-summary',
+        sql: `EXPLAIN ANALYZE SELECT COALESCE(SUM(cost),0) FROM youtube_ad_insights WHERE date_start >= CURRENT_DATE - INTERVAL '7 days'`,
+      },
+      {
+        name: 'rows-query',
+        sql: `EXPLAIN ANALYZE SELECT * FROM (
+          SELECT date_start, 'facebook' AS platform, account_id, NULL::text AS campaign_id, campaign_name, adset_name, ad_name,
+          impressions, clicks, spend, COALESCE(purchase_roas * spend,0)::numeric AS revenue,
+          CASE WHEN spend > 0 THEN COALESCE(purchase_roas * spend,0)/spend ELSE NULL END AS roas
+          FROM facebook_ad_insights
+          WHERE date_start BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE
+          UNION ALL
+          SELECT date_start, 'youtube' AS platform, NULL::text AS account_id, NULL::text AS campaign_id, campaign_name,
+          NULL::text AS adset_name, NULL::text AS ad_name, impressions, clicks, cost AS spend, 0::numeric AS revenue,
+          CASE WHEN cost > 0 THEN 0 ELSE NULL END AS roas
+          FROM youtube_ad_insights
+          WHERE date_start BETWEEN CURRENT_DATE - INTERVAL '7 days' AND CURRENT_DATE
+        ) AS sub ORDER BY date_start DESC LIMIT 100` ,
+      },
+    ];
+
+    for (const q of queries) {
+      const res = await client.query(q.sql);
+      const plan = res.rows.map((r) => r['QUERY PLAN']).join('\n');
+      log(`${q.name} plan:\n${plan}`);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  logPlans()
+    .then(() => {
+      process.exit(0);
+    })
+    .catch((err) => {
+      console.error(err);
+      process.exit(1);
+    });
+}

--- a/summaryCache.js
+++ b/summaryCache.js
@@ -1,0 +1,34 @@
+class LRUCache {
+  constructor(limit = 5, ttlMs = 60 * 1000) {
+    this.limit = limit;
+    this.ttl = ttlMs;
+    this.map = new Map();
+  }
+
+  get(key) {
+    const entry = this.map.get(key);
+    const now = Date.now();
+    if (!entry) return null;
+    if (now - entry.time > this.ttl) {
+      this.map.delete(key);
+      return null;
+    }
+    this.map.delete(key);
+    this.map.set(key, { value: entry.value, time: entry.time });
+    return entry.value;
+  }
+
+  set(key, value) {
+    if (this.map.has(key)) {
+      this.map.delete(key);
+    }
+    this.map.set(key, { value, time: Date.now() });
+    if (this.map.size > this.limit) {
+      const firstKey = this.map.keys().next().value;
+      this.map.delete(firstKey);
+    }
+  }
+}
+
+export const summaryCache = new LRUCache();
+export { LRUCache };


### PR DESCRIPTION
## Summary
- add helper to ensure ad insight indexes exist
- add circuit breaker retry wrapper and LRU summary cache
- log explain analyze plans for common queries

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a0fba213c832baa2fdca393def20d