### PR TITLE
feat: add PG_SSL_MODE support and pool accessor

### DIFF
--- a/db.js
+++ b/db.js
@@ -1,1 +1,1 @@
-export { pool } from './lib/db.js';
+export { pool, getPool } from './lib/db.js';

--- a/lib/db.js
+++ b/lib/db.js
@@ -2,33 +2,55 @@ import 'dotenv/config';
 import fs from 'fs';
 import { Pool } from 'pg';
 
-const uri = process.env.PG_URI;
-if (!uri) {
-  throw new Error('PG_URI is not set');
-}
+let poolInstance;
 
-// Prefer explicit CA path if provided; otherwise use certs/db-ca.pem if present; else fallback
-let sslConfig = { rejectUnauthorized: false }; // works with DO sslmode=require
-try {
-  const caPath = process.env.PG_CA_PATH || './certs/db-ca.pem';
-  if (fs.existsSync(caPath)) {
-    const ca = fs.readFileSync(caPath).toString();
-    sslConfig = { rejectUnauthorized: true, ca };
+function createSslConfig() {
+  const mode = process.env.PG_SSL_MODE || 'require';
+  switch (mode) {
+    case 'disable':
+      return false;
+    case 'require':
+      return { rejectUnauthorized: false };
+    case 'verify-ca': {
+      const caPath = process.env.PG_CA_PATH || './certs/db-ca.pem';
+      if (fs.existsSync(caPath)) {
+        const ca = fs.readFileSync(caPath).toString();
+        return { rejectUnauthorized: true, ca };
+      }
+      throw new Error(
+        'PG_SSL_MODE=verify-ca requires PG_CA_PATH or ./certs/db-ca.pem'
+      );
+    }
+    default:
+      throw new Error(`Invalid PG_SSL_MODE: ${mode}`);
   }
-} catch (e) {
-  // keep fallback
 }
 
-const pool = new Pool({
-  connectionString: uri,
-  ssl: sslConfig,
-  max: Number(process.env.PG_POOL_MAX || 8),
-  idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS || 10000),
-  connectionTimeoutMillis: Number(process.env.PG_CONN_TIMEOUT_MS || 5000)
-});
+function getPool() {
+  if (!poolInstance) {
+    const uri = process.env.PG_URI;
+    if (!uri) {
+      throw new Error('PG_URI is not set');
+    }
+    const ssl = createSslConfig();
+    poolInstance = new Pool({
+      connectionString: uri,
+      ssl,
+      max: Number(process.env.PG_POOL_MAX || 8),
+      idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS || 10000),
+      connectionTimeoutMillis: Number(
+        process.env.PG_CONN_TIMEOUT_MS || 5000
+      )
+    });
 
-pool.on('error', (err) => {
-  console.error('Postgres pool error:', err);
-});
+    poolInstance.on('error', (err) => {
+      console.error('Postgres pool error:', err);
+    });
+  }
+  return poolInstance;
+}
 
-export { pool };
+const pool = getPool();
+
+export { pool, getPool };
+


### PR DESCRIPTION
## Summary
- add `PG_SSL_MODE` env handling for disable, require, and verify-ca modes
- expose `getPool()` to reuse a singleton Postgres connection pool

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689bab2f1568832b880a724899f3d899