### PR TITLE
Add summary and rows endpoints with SSL bypass

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,34 +1,14 @@
-import 'dotenv/config';
-import fs from 'fs';
 import { Pool } from 'pg';
-
-function resolveSSL() {
-  const mode = (process.env.PG_SSL_MODE || 'require').toLowerCase();
-  const caPath = process.env.PG_CA_PATH;
-
-  // Explicit CA takes precedence if present
-  if (caPath && fs.existsSync(caPath)) {
-    return { ca: fs.readFileSync(caPath, 'utf8') };
-  }
-
-  // Map common modes -> node-postgres ssl options
-  if (mode === 'disable') return false;
-  if (mode === 'no-verify' || mode === 'require') return { rejectUnauthorized: false };
-  if (mode === 'verify-full') {
-    // verify-full without a CA is impossible; fallback to no-verify
-    return { rejectUnauthorized: false };
-  }
-  // default
-  return { rejectUnauthorized: false };
-}
 
 export const pool = new Pool({
   connectionString: process.env.PG_URI,
-  ssl: resolveSSL(),
+  // TEMPORARY: bypass self-signed cert issues without changing .env
+  ssl: { rejectUnauthorized: false },
   max: Number(process.env.PG_POOL_MAX || 10),
   idleTimeoutMillis: Number(process.env.PG_IDLE_TIMEOUT_MS || 10000),
   connectionTimeoutMillis: Number(process.env.PG_CONN_TIMEOUT_MS || 5000)
 });
 
-export function getPool() { return pool; }
-
+export function getPool() {
+  return pool;
+}


### PR DESCRIPTION
## Summary
- disable SSL verification in Postgres pool to work with self-signed certs
- add `/api/summary` and `/api/rows` endpoints protected by x-api-key

## Testing
- `npm test`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_689bbbcc58f4832ba38f4791b14c3590