### PR TITLE
feat: add script to create users

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -24,3 +24,8 @@ export async function query(q, params = []) {
     client.release();
   }
 }
+
+// helper to retrieve the pool
+export function getPool() {
+  return pool;
+}

--- a/scripts/createUser.js
+++ b/scripts/createUser.js
@@ -1,0 +1,30 @@
+// scripts/createUser.js
+import bcrypt from 'bcrypt';
+import { getPool } from '../lib/db.js';
+
+const email = process.argv[2];
+const password = process.argv[3];
+
+if (!email || !password) {
+  console.error('Usage: node scripts/createUser.js <email> <password>');
+  process.exit(1);
+}
+
+const hashPassword = async (plain) => {
+  const saltRounds = 12;
+  return bcrypt.hash(plain, saltRounds);
+};
+
+(async () => {
+  try {
+    const pool = await getPool();
+    const hash = await hashPassword(password);
+    await pool.query('INSERT INTO users (email, password_hash) VALUES ($1, $2)', [email, hash]);
+    console.log(`✅ User ${email} created`);
+    process.exit(0);
+  } catch (err) {
+    console.error('User creation failed:', err.message);
+    process.exit(1);
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add helper to fetch DB pool
- add `scripts/createUser.js` for creating users

## Testing
- `npm test`
- `node scripts/createUser.js "jenny@beautybyearth.com" "bBEHappy#120!ADS"` *(fails: connect ENETUNREACH 67.205.158.255:25060)*

------
https://chatgpt.com/codex/tasks/task_e_689be8ba7b98832b95d923c6c85ebdc7