### PR TITLE
feat: serve UI with session auth and pm2 config

### DIFF
--- a/cron.js
+++ b/cron.js
@@ -7,6 +7,7 @@ import { runDailyCreativeRecs } from "./dailyCreative.js";
 import { getAuthedOAuth2 } from "./lib/googleOAuth.js";
 import { yesterdayRange, todayRange } from "./lib/date.js";
 import { log, logError } from "./logger.js";
+import { refreshRecentWindows } from "./lib/rollups.js";
 
 const TZ = process.env.TZ || "UTC";
 
@@ -21,6 +22,7 @@ async function syncToday() {
       await logError(`cron today ${name} failed`, e);
     }
   }
+  try { await refreshRecentWindows(); } catch (e) { await logError('cron refreshRecentWindows failed', e); }
 }
 
 async function archiveYesterday() {
@@ -34,6 +36,7 @@ async function archiveYesterday() {
       await logError(`cron yesterday ${name} failed`, e);
     }
   }
+  try { await refreshRecentWindows(); } catch (e) { await logError('cron refreshRecentWindows failed', e); }
 }
 
 // 4× per day: 00:15, 06:15, 12:15, 18:15 (local TZ)

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,18 @@
+module.exports = {
+  apps: [
+    {
+      name: 'adshub-api',
+      script: './server.js',
+      env: {
+        NODE_ENV: 'production'
+      }
+    },
+    {
+      name: 'adshub-cron',
+      script: './cron.js',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
+};

--- a/lib/db.js
+++ b/lib/db.js
@@ -1,13 +1,20 @@
 import pg from 'pg';
 const { Pool } = pg;
 
-const useSSL = /\bsslmode=require\b/i.test(process.env.PG_URI || '');
-const ssl =
-  useSSL
-    ? (process.env.PG_CA_PATH
-        ? { ca: await (await import('fs')).promises.readFile(process.env.PG_CA_PATH, 'utf8') }
-        : { rejectUnauthorized: false })
-    : false;
+const useSSL =
+  process.env.PG_SSL_MODE === 'require' ||
+  /\bsslmode=require\b/i.test(process.env.PG_URI || '');
+
+let ssl = false;
+if (useSSL) {
+  if (process.env.PG_CA_PATH) {
+    ssl = {
+      ca: await (await import('fs')).promises.readFile(process.env.PG_CA_PATH, 'utf8')
+    };
+  } else {
+    ssl = { rejectUnauthorized: false };
+  }
+}
 
 export const pool = new Pool({
   connectionString: process.env.PG_URI,

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "backfill": "node backfill.js",
     "rotate-token": "node rotateToken.js",
     "ui": "npm --prefix ui run dev",
-    "ui:build": "npm --prefix ui run build",
+    "ui:build": "node scripts/buildUi.js",
     "ui:lint": "npm --prefix ui run lint",
     "start:web": "npm run ui:build && node server.js",
     "migrate": "node scripts/migrate.js",

--- a/scripts/backfill.js
+++ b/scripts/backfill.js
@@ -1,0 +1,41 @@
+import 'dotenv/config';
+import { fetchFacebookInsights } from '../facebookInsights.js';
+import { fetchYouTubeInsights } from '../youtubeInsights.js';
+import { insertOnly } from '../saveToDatabase.js';
+import { refreshDailyRollup } from '../lib/rollups.js';
+
+const args = process.argv.slice(2);
+const opts = {};
+for (let i = 0; i < args.length; i += 2) {
+  const key = args[i];
+  const val = args[i + 1];
+  if (key && key.startsWith('--')) opts[key.slice(2)] = val;
+}
+
+const { source, start, end } = opts;
+if (!source || !start || !end) {
+  console.error('Usage: node scripts/backfill.js --source facebook --start YYYY-MM-DD --end YYYY-MM-DD');
+  process.exit(1);
+}
+
+const fetcher = source === 'facebook'
+  ? fetchFacebookInsights
+  : source === 'youtube'
+    ? fetchYouTubeInsights
+    : null;
+
+if (!fetcher) {
+  console.error('Unknown source:', source);
+  process.exit(1);
+}
+
+(async () => {
+  const rows = await fetcher({ since: start, until: end });
+  const r = await insertOnly(source, rows);
+  await refreshDailyRollup(start, end);
+  console.log(`Backfill complete for ${source}: inserted ${r.inserted}`);
+  process.exit(0);
+})().catch(err => {
+  console.error('Backfill failed:', err.message);
+  process.exit(1);
+});

--- a/scripts/buildUi.js
+++ b/scripts/buildUi.js
@@ -1,0 +1,19 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import dotenv from 'dotenv';
+
+dotenv.config();
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const uiDir = path.join(__dirname, '..', 'ui');
+
+const env = {
+  ...process.env,
+  VITE_API_BASE: process.env.VITE_API_BASE || process.env.API_BASE || '',
+  VITE_SYNC_API_KEY: process.env.VITE_SYNC_API_KEY || process.env.SYNC_API_KEY || ''
+};
+
+const child = spawn('npm', ['run', 'build'], { cwd: uiDir, stdio: 'inherit', env });
+child.on('exit', code => process.exit(code));

--- a/server.js
+++ b/server.js
@@ -1,16 +1,45 @@
+import 'dotenv/config';
 import express from 'express';
 import morgan from 'morgan';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import session from 'express-session';
+import connectPgSimple from 'connect-pg-simple';
 import api from './routes/api.js';
+import authRoutes from './routes/auth.js';
+import { pool } from './lib/db.js';
 
 const app = express();
 app.set('trust proxy', true);
 
 app.use(morgan('tiny'));
 app.use(express.json({ limit: '2mb' }));
+
+const origins = (process.env.CORS_ORIGINS || '')
+  .split(',')
+  .map(s => s.trim())
+  .filter(Boolean);
+
 app.use(cors({
-  origin: true, // allow UI on a different host
-  credentials: false
+  origin: (origin, cb) => {
+    if (!origin) return cb(null, true);
+    cb(null, origins.includes(origin));
+  },
+  credentials: true
+}));
+
+const PgStore = connectPgSimple(session);
+app.use(session({
+  store: new PgStore({ pool }),
+  secret: process.env.SESSION_SECRET || 'change-me',
+  resave: false,
+  saveUninitialized: false,
+  cookie: {
+    maxAge: 1000 * 60 * 60 * 24 * 30, // 30 days
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production'
+  }
 }));
 
 // health endpoints (no API key)
@@ -23,14 +52,30 @@ app.get('/healthz', (_req, res) => res.json({
 app.get('/readyz', (_req, res) => res.json({ ok: true }));
 
 // mount API
+app.use('/auth', authRoutes);
+
+// mount API
 app.use('/api', api);
+// API 404 guard
+app.use('/api', (_req, res) => res.status(404).json({ error: 'not-found' }));
+
+// static UI
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const distPath = path.join(__dirname, 'ui', 'dist');
+app.use(express.static(distPath));
 
 // 404 guard (after mounting API)
-app.use((req, res) => {
-  if (req.path.startsWith('/api/')) {
-    return res.status(404).json({ error: 'not-found' });
+app.use((req, res, next) => {
+  if (req.path.startsWith('/api/') || req.path.startsWith('/auth/') ||
+      req.path === '/healthz' || req.path === '/readyz') {
+    return next();
   }
-  res.status(404).send('Not found');
+
+  if (!req.session?.user && req.path !== '/login') {
+    return res.redirect('/login');
+  }
+
+  return res.sendFile(path.join(distPath, 'index.html'));
 });
 
 const port = Number(process.env.PORT || 3000);


### PR DESCRIPTION
## Summary
- serve built React UI with session-based login and API CORS restrictions
- add scripts for UI build and historical backfill plus pm2 ecosystem config
- improve database SSL handling and Facebook fetcher token resilience

## Testing
- `npm test`
- `npm run ui:build`


------
https://chatgpt.com/codex/tasks/task_e_689bf272f930832b9b9bb4a7772393fe