### PR TITLE
chore: update production UI API base to HTTPS domain

### DIFF
--- a/ui/.env.production
+++ b/ui/.env.production
@@ -1,3 +1,3 @@
-VITE_API_BASE=https://<YOUR_DROPLET_IP>
+VITE_API_BASE=https://ads.beautybyearth.com
 VITE_SYNC_API_KEY=<YOUR_SYNC_API_KEY>
 VITE_BRAND_NAME=AdsHub


### PR DESCRIPTION
## Summary
- point `VITE_API_BASE` in production UI env to `https://ads.beautybyearth.com`

## Testing
- `npm test`
- `npm --prefix ui run build`


------
https://chatgpt.com/codex/tasks/task_e_689c0788b718832bb9f38a74c05bb083