### PR TITLE
Centralize Postgres pool and cleanup stray Pool usage

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -2,8 +2,15 @@ import { Pool } from 'pg';
 import fs from 'fs';
 
 const uri = process.env.PG_URI;
-const sslMode = (process.env.PG_SSL || 'verify').toLowerCase(); // 'verify' | 'require' | 'disable'
-const caPath = process.env.PG_CA_CERT; // e.g. /etc/ssl/certs/do-postgres-ca.crt
+if (!uri) throw new Error('PG_URI not set');
+
+/**
+ * PG_SSL modes:
+ *  - verify (default): verify server cert; if PG_CA_CERT file exists, use it.
+ *  - require: TLS but don't verify (rejectUnauthorized:false)
+ *  - disable: no TLS (not recommended)
+ */
+const sslMode = (process.env.PG_SSL || 'verify').toLowerCase();
 
 let ssl;
 if (sslMode === 'disable') {
@@ -11,9 +18,11 @@ if (sslMode === 'disable') {
 } else if (sslMode === 'require') {
   ssl = { rejectUnauthorized: false };
 } else {
-  // verify
-  const ca = caPath && fs.existsSync(caPath) ? fs.readFileSync(caPath, 'utf8') : undefined;
-  ssl = ca ? { ca } : { rejectUnauthorized: true };
+  const caPath = process.env.PG_CA_CERT;
+  // If a CA file is present, use it; otherwise allow native bundle verify.
+  ssl = (caPath && fs.existsSync(caPath))
+    ? { ca: fs.readFileSync(caPath, 'utf8') }
+    : true;
 }
 
 export const pool = new Pool({
@@ -22,10 +31,12 @@ export const pool = new Pool({
 });
 
 export async function query(text, params) {
-  const client = await pool.connect();
-  try {
-    return await client.query(text, params);
-  } finally {
-    client.release();
+  const start = Date.now();
+  const res = await pool.query(text, params);
+  const duration = Date.now() - start;
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('executed query', { text, duration, rows: res.rowCount });
   }
+  return res;
 }
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "connect-pg-simple": "^10.0.0",
         "cookie-parser": "^1.4.6",
         "cors": "^2.8.5",
-        "dotenv": "^16.4.5",
+        "dotenv": "^16.6.1",
         "express": "^4.19.2",
         "express-basic-auth": "^1.2.1",
         "express-session": "^1.18.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "connect-pg-simple": "^10.0.0",
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.6.1",
     "express": "^4.19.2",
     "express-basic-auth": "^1.2.1",
     "express-session": "^1.18.2",

--- a/reportSummary.js
+++ b/reportSummary.js
@@ -1,12 +1,9 @@
 import axios from 'axios';
-import pkg from 'pg';
 import dotenv from 'dotenv';
 import { log } from './logger.js';
+import { pool } from './lib/db.js';
 
 dotenv.config();
-
-const { Pool } = pkg;
-import { pool } from './lib/db.js';
 
 export async function runReport() {
   if (!process.env.PG_URI) {

--- a/scripts/createUser.js
+++ b/scripts/createUser.js
@@ -1,6 +1,6 @@
 // scripts/createUser.js
 import bcrypt from 'bcrypt';
-import { getPool } from '../lib/db.js';
+import { pool } from '../lib/db.js';
 
 const email = process.argv[2];
 const password = process.argv[3];
@@ -11,7 +11,6 @@ if (!email || !password) {
 }
 
 (async () => {
-  const pool = await getPool();
   const hash = await bcrypt.hash(password, 12);
 
   // make sure table exists

--- a/services/facebookFetch.js
+++ b/services/facebookFetch.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { DateTime } from 'luxon';
-import { getPool } from '../lib/db.js';
+import { pool } from '../lib/db.js';
 
 const API_BASE = 'https://graph.facebook.com/v18.0';
 
@@ -32,7 +32,6 @@ export async function facebookFetch({ since, until } = {}) {
   const acts = accounts();
   if (!acts.length) throw new Error('FB_AD_ACCOUNTS missing');
 
-  const pool = getPool();
   const start = DateTime.fromISO(since || DateTime.utc().minus({ days: 1 }).toISODate());
   const end = DateTime.fromISO(until || start.toISODate());
   let inserted = 0;


### PR DESCRIPTION
## Summary
- add unified `lib/db.js` with selectable SSL modes and query logging
- refactor scripts to import shared pool instead of creating new ones
- remove direct `pg` imports and update dotenv dependency

## Testing
- `npm test`
- `rg "new Pool" -n | grep -v 'lib/db.js'`
- `rg "pg\.Pool" -n`
- `rg "import \{ Pool \} from 'pg'" -n | grep -v 'lib/db.js'`


------
https://chatgpt.com/codex/tasks/task_e_689d020da484832ba5848ffa3cb76b16