### PR TITLE
Configure PM2 to run server.js

### DIFF
--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,7 +1,16 @@
 module.exports = {
-  apps: [{
-    name: 'adshub',
-    script: 'server.js',
-    env: { NODE_ENV: 'production' }
-  }]
+  apps: [
+    {
+      name: 'adshub',
+      script: 'server.js',
+      cwd: '/root/AdsHub',
+      node_args: [],
+      watch: false,
+      instances: 1,
+      exec_mode: 'fork',
+      env: {
+        NODE_ENV: 'production'
+      }
+    }
+  ]
 };


### PR DESCRIPTION
## Summary
- define a complete PM2 ecosystem config targeting `server.js`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `pm2 start ecosystem.config.cjs`
- `pm2 status`
- `curl -sS http://127.0.0.1:3000/healthz`
- `curl -sS http://127.0.0.1:3000/readyz`


------
https://chatgpt.com/codex/tasks/task_e_689d4a0b5734832b8d857840fe35f0d7