### PR TITLE
chore: centralize postgres pool and simplify server

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -1,55 +1,35 @@
 // lib/db.js
 import { Pool } from 'pg';
 import fs from 'fs';
+import url from 'url';
 
 const uri = process.env.PG_URI;
-if (!uri) {
-  console.warn('[db] PG_URI not set — DB calls will fail until it is.');
+if (!uri) throw new Error('PG_URI not set');
+
+const sslMode = (process.env.PG_SSL || 'verify').toLowerCase(); // verify | require | disable
+let ssl;
+if (sslMode === 'disable') {
+  ssl = false;
+} else if (sslMode === 'require') {
+  ssl = { rejectUnauthorized: false };
 } else {
-  try {
-    console.log('[db] host=' + new URL(uri).host);
-  } catch {}
-}
-
-const sslMode = (process.env.PG_SSL || 'verify').toLowerCase();
-
-function buildSsl() {
-  if (sslMode === 'disable') return false;
-  if (sslMode === 'require') return { rejectUnauthorized: false };
-  // 'verify' (default)
+  // verify (default)
   const caPath = process.env.PG_CA_CERT;
-  if (!caPath || !fs.existsSync(caPath)) {
-    console.warn(`[db] PG_SSL=verify but PG_CA_CERT missing or unreadable: ${caPath || '(unset)'}`);
-    // Fall back to require (don’t block startup)
-    return { rejectUnauthorized: false };
-  }
-  return { ca: fs.readFileSync(caPath, 'utf8'), rejectUnauthorized: true };
+  ssl = caPath && fs.existsSync(caPath)
+    ? { ca: fs.readFileSync(caPath, 'utf8') }
+    : { rejectUnauthorized: true };
 }
 
 export const pool = new Pool({
   connectionString: uri,
-  ssl: buildSsl()
+  ssl,
+  max: Number(process.env.PG_POOL_MAX || 10),
+  idleTimeoutMillis: Number(process.env.PG_IDLE_MS || 30000),
+  connectionTimeoutMillis: Number(process.env.PG_CONNECT_MS || 10000),
 });
 
-export async function dbReady(timeoutMs = 3000) {
-  // Quick readiness probe — a cheap query with timeout
-  const ctrl = new AbortController();
-  const t = setTimeout(() => ctrl.abort(), timeoutMs);
-  try {
-    const client = await pool.connect();
-    try {
-      await client.query('SELECT 1');
-      return true;
-    } finally {
-      client.release();
-    }
-  } catch (e) {
-    return false;
-  } finally {
-    clearTimeout(t);
-  }
-}
-
-export async function query(text, params) {
-  return pool.query(text, params);
-}
+// log DB host once for sanity
+try {
+  const u = new url.URL(uri);
+  console.log(`[db] host=${u.hostname}:${u.port || 5432} db=${u.pathname.replace('/','')}`);
+} catch {}

--- a/server.js
+++ b/server.js
@@ -1,33 +1,22 @@
 import 'dotenv/config';
-import http from 'http';
 import express from 'express';
 import { pool } from './lib/db.js';
 
+const app = express();
 const HOST = process.env.HOST || '0.0.0.0';
 const PORT = Number(process.env.PORT || 3000);
-const app = express();
 
-app.use((req,res,next)=>{ try{ console.log('REQ', req.method, req.url); }catch(e){} next(); });
-
-app.get('/healthz', (_req, res) => {
-  res.status(200).json({ ok: true, service: 'api', ver: '0.0.0' });
-});
+app.get('/healthz', (_req, res) => res.json({ ok: true }));
 
 app.get('/readyz', async (_req, res) => {
   try {
-    const ctl = new AbortController();
-    const t = setTimeout(()=>ctl.abort(), 3000);
-    const r = await pool.query({ text: 'SELECT 1', signal: ctl.signal });
-    clearTimeout(t);
-    return res.status(200).json({ ok: true, db: 'up', rows: r.rowCount });
+    await pool.query('SELECT 1');
+    res.json({ ok: true });
   } catch (err) {
-    return res.status(503).json({ ok: false, reason: 'db-error', error: String(err && err.message || err) });
+    res.status(503).json({ ok: false, reason: 'db-error', error: String(err.message || err) });
   }
 });
 
-app.get('/', (_req, res) => res.status(200).send('OK'));
-
-const server = http.createServer(app);
-server.listen(PORT, HOST, () => {
+app.listen(PORT, HOST, () => {
   console.log(`[start] adshub-api listening on http://${HOST}:${PORT}`);
 });


### PR DESCRIPTION
## Summary
- centralize PG connection using a shared pool with SSL options
- simplify server startup and reuse shared pool for readiness check

## Testing
- `npm test` *(fails: Missing script "test")*
- `node --version`
- `curl -sS http://127.0.0.1:3000/healthz`
- `curl -sS http://127.0.0.1:3000/readyz`
- `pm2 start server.js --name adshub --update-env`
- `pm2 status`
- `pm2 logs adshub --lines 60`
- `curl -sS http://127.0.0.1:3000/healthz`
- `curl -sS http://127.0.0.1:3000/readyz`
- `node -e "require('dotenv').config(); const m=k=>String(process.env[k]||''); console.log('PG_URI=', m('PG_URI').slice(0,50)+'...'); console.log('PG_SSL=', m('PG_SSL')); console.log('PG_CA_CERT exists=', require('fs').existsSync(m('PG_CA_CERT')))"`


------
https://chatgpt.com/codex/tasks/task_e_689d6e298824832b92e54d7d19b4727d