### PR TITLE
chore: configure DigitalOcean build and update tailwind

### DIFF
--- a/.do/app.yaml
+++ b/.do/app.yaml
@@ -1,0 +1,8 @@
+spec:
+  name: adshub
+  services:
+    - name: web
+      environment_slug: node-js
+      source_dir: .
+      build_command: npm run build
+      run_command: npm start

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,6 @@
       "name": "adshub-ui",
       "version": "1.0.0",
       "dependencies": {
-        "autoprefixer": "^10.4.21",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^7.8.1",
@@ -17,6 +16,7 @@
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.12",
         "@vitejs/plugin-react": "^4.0.0",
+        "autoprefixer": "^10.4.21",
         "eslint": "^8.56.0",
         "eslint-plugin-react": "^7.33.2",
         "vite": "^5.0.0"
@@ -1792,6 +1792,7 @@
       "version": "10.4.21",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
       "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1863,6 +1864,7 @@
       "version": "4.25.2",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.2.tgz",
       "integrity": "sha512-0si2SJK3ooGzIawRu61ZdPCO1IncZwS8IzuX73sPZsXW6EQ/w/DAfPyKI8l1ETTCr2MnvqWitmlCUxgdul45jA==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -1955,6 +1957,7 @@
       "version": "1.0.30001735",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001735.tgz",
       "integrity": "sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2213,6 +2216,7 @@
       "version": "1.5.202",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.202.tgz",
       "integrity": "sha512-NxbYjRmiHcHXV1Ws3fWUW+SLb62isauajk45LUJ/HgIOkUA7jLZu/X2Iif+X9FBNK8QkF9Zb4Q2mcwXCcY30mg==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/enhanced-resolve": {
@@ -2449,6 +2453,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2767,6 +2772,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
       "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "*"
@@ -4072,6 +4078,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4097,12 +4104,14 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-range": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
       "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -4348,6 +4357,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/possible-typed-array-names": {
@@ -4364,6 +4374,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -4392,6 +4403,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
       "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/prelude-ls": {
@@ -4923,6 +4935,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
       "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
@@ -5270,6 +5283,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
       "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/ui/package.json
+++ b/ui/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
-    "autoprefixer": "^10.4.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.8.1",
@@ -17,6 +16,7 @@
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.12",
+    "autoprefixer": "^10.4.21",
     "@vitejs/plugin-react": "^4.0.0",
     "eslint": "^8.56.0",
     "eslint-plugin-react": "^7.33.2",

--- a/ui/postcss.config.js
+++ b/ui/postcss.config.js
@@ -1,8 +1,6 @@
-const tailwindcss = require('@tailwindcss/postcss');
-
 module.exports = {
-  plugins: [
-    tailwindcss(),
-    require('autoprefixer')
-  ]
+  plugins: {
+    '@tailwindcss/postcss': {},
+    'autoprefixer': {},
+  },
 };


### PR DESCRIPTION
## Summary
- add `.do/app.yaml` with explicit build and run commands for DigitalOcean App Platform
- fix Tailwind/PostCSS setup for v3.4+ and ensure `@tailwindcss/postcss` and `autoprefixer` are dev dependencies

## Testing
- `npm test`
- `npm run build`
- `npm run ui:lint` *(fails: 100 errors, no-unused-vars, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689fd47a4080832b8fc7027657613b82