### PR TITLE
chore: configure ESLint for UI

### DIFF
--- a/ui/.eslintignore
+++ b/ui/.eslintignore
@@ -1,0 +1,7 @@
+dist/
+node_modules/
+vite.config.js
+tailwind.config.js
+postcss.config.js
+*.config.js
+*.config.cjs

--- a/ui/.eslintrc.cjs
+++ b/ui/.eslintrc.cjs
@@ -1,0 +1,20 @@
+module.exports = {
+  env: {
+    browser: true,
+    es2021: true,
+  },
+  extends: ['eslint:recommended', 'plugin:react/recommended'],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+  },
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+  },
+};

--- a/ui/package.json
+++ b/ui/package.json
@@ -6,7 +6,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx"
+    "lint": "eslint src --ext .js,.jsx,.ts,.tsx"
   },
   "dependencies": {
     "react": "^18.2.0",


### PR DESCRIPTION
## Summary
- add React-friendly ESLint config for the UI
- ignore build and config artifacts when linting
- lint only `src` files via package script

## Testing
- `npm run ui:lint`
- `npm run build`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689fe2863578832b89b70fdad9e4445d