### PR TITLE
Fix 500 error: Skip .env file loading in production

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -6,23 +6,26 @@ import path from 'path';
 
 const NODE_ENV = process.env.NODE_ENV || 'development';
 
-// Determine which .env file to load
-let envFile;
+// Skip .env file loading in production (DigitalOcean sets env vars directly)
 if (NODE_ENV === 'production') {
-  envFile = '.env';
-} else if (NODE_ENV === 'development') {
-  envFile = '.env.dev';
+  console.log(`🚀 Production mode: Using environment variables from platform (NODE_ENV=${NODE_ENV})`);
 } else {
-  envFile = '.env';
-}
+  // Determine which .env file to load for development
+  let envFile;
+  if (NODE_ENV === 'development') {
+    envFile = '.env.dev';
+  } else {
+    envFile = '.env';
+  }
 
-// Check if the file exists
-if (fs.existsSync(envFile)) {
-  console.log(`🔧 Loading environment from: ${envFile} (NODE_ENV=${NODE_ENV})`);
-  dotenv.config({ path: envFile });
-} else {
-  console.log(`⚠️  Environment file ${envFile} not found, using default .env`);
-  dotenv.config();
+  // Check if the file exists
+  if (fs.existsSync(envFile)) {
+    console.log(`🔧 Loading environment from: ${envFile} (NODE_ENV=${NODE_ENV})`);
+    dotenv.config({ path: envFile });
+  } else {
+    console.log(`⚠️  Environment file ${envFile} not found, using default .env`);
+    dotenv.config();
+  }
 }
 
 export { NODE_ENV };


### PR DESCRIPTION
CRITICAL FIX:
✅ Skip .env file loading when NODE_ENV=production
✅ Use DigitalOcean environment variables directly in production ✅ Only load .env files in development mode

ISSUE: lib/env.js was trying to load .env files in production, which could interfere with environment variables already set in DigitalOcean App Platform UI.

SOLUTION: In production, trust platform environment variables and don't attempt to load from files.

RESULT: Should fix 500 error and use your existing DO env vars! 🚀